### PR TITLE
Set default_timezone per default

### DIFF
--- a/app/config/core.php
+++ b/app/config/core.php
@@ -245,7 +245,7 @@
  * If you are on PHP 5.3 uncomment this line and correct your server timezone
  * to fix the date & time related errors.
  */
-	//date_default_timezone_set('UTC');
+	date_default_timezone_set('UTC');
 
 /**
  *


### PR DESCRIPTION
With the current PHP 5.3 and 5.4 release the setting of the default_timezone should be default. 
